### PR TITLE
Berkeley DB v6 compatibility fix

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -43,7 +43,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LogPrintf("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
 
 void CDBEnv::Reset()


### PR DESCRIPTION
Fixes building error looking like this:
  CXX      wallet/libbitcoin_wallet_a-db.o
wallet/db.cpp: In member function ‘void CDBEnv::EnvShutdown()’:
wallet/db.cpp:46:16: error: call of overloaded ‘DbEnv(int)’ is ambiguous
         DbEnv(0).remove(strPath.c_str(), 0);
                ^
wallet/db.cpp:46:16: note: candidates are:
In file included from wallet/db.h:21:0,
                 from wallet/db.cpp:6:
/usr/include/db_cxx.h:916:2: note: DbEnv::DbEnv(const DbEnv&)
  DbEnv(const DbEnv &);
  ^
/usr/include/db_cxx.h:518:2: note: DbEnv::DbEnv(DB_ENV_)
  DbEnv(DB_ENV *dbenv);
  ^
/usr/include/db_cxx.h:516:2: note: DbEnv::DbEnv(u_int32_t)
  DbEnv(u_int32_t flags);
  ^
Makefile:5780: recipe for target 'wallet/libbitcoin_wallet_a-db.o' failed
make[2]: *_\* [wallet/libbitcoin_wallet_a-db.o] Error 1
